### PR TITLE
time series resolution duration calculation

### DIFF
--- a/quantfinlib/util/timeseries.py
+++ b/quantfinlib/util/timeseries.py
@@ -126,3 +126,63 @@ def infer_time_series_resolution(ts_obj) -> Optional[str]:
 
     return None
 
+# Private dictionary mapping time series resolutions to their respective durations in years
+_time_series_resolution_duration_map = {
+    'D': 1.0 / 365.0,
+    'B': 1.0 / 252.0,
+    'W': 7.0 / 365.0,
+    'ME': 1.0 / 12.0,
+    'MS': 1.0 / 12.0,
+    'QE': 1.0 / 4.0,
+    'QS': 1.0 / 4.0,
+    'YE': 1.0,
+    'YS': 1.0
+}
+
+def time_series_resolution_duration(freq: str) -> Optional[float]:
+    """
+    Get the duration of a time series resolution in years.
+
+    This function takes a frequency code representing the time series resolution
+    and returns the corresponding duration in years. The mapping is based on the
+    private dictionary `_time_series_resolution_duration_map`.
+
+    Parameters
+    ----------
+    freq : str
+        The frequency code of the time series resolution. Supported codes are:
+
+        * 'D'  : Daily resolution (7 days a week) = 1/365
+        * 'B'  : Working-day resolution (roughly 5 days a week) = 1/252
+        * 'W'  : Weekly resolution = 7/365
+        * 'ME' : Month-end resolution = 1/12
+        * 'MS' : Month-start resolution = 1/12
+        * 'QE' : Quarter-end resolution = 1/4
+        * 'QS' : Quarter-start resolution = 1/4
+        * 'YE' : Year-end resolution = 1
+        * 'YS' : Year-start resolution = 1
+
+    Returns
+    -------
+    Optional[float]
+        The duration of the given frequency in years, or None if the frequency code is not recognized.
+
+    Examples
+    --------
+    >>> time_series_resolution_duration('D')
+    0.0027397260273972603
+
+    >>> time_series_resolution_duration('B')
+    0.003968253968253968
+
+    >>> time_series_resolution_duration('W')
+    0.019178082191780823
+
+    >>> time_series_resolution_duration('ME')
+    0.08333333333333333
+
+    >>> time_series_resolution_duration('XYZ')  # Unrecognized frequency code
+    None
+    """        
+    return _time_series_resolution_duration_map.get(freq, None)
+

--- a/tests/util/test_timeseries.py
+++ b/tests/util/test_timeseries.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 import pytest
 
-from quantfinlib.util.timeseries import infer_time_series_resolution
+from quantfinlib.util.timeseries import infer_time_series_resolution, time_series_resolution_duration
 
 def _make_df(freq):  
     date_rng = pd.date_range(start='2020-01-12', end='2024-12-31', freq=freq)
@@ -30,3 +30,19 @@ def test_infer_time_series_resolution():
     # Test a frequency we dont support (every 2 days)
     df = _make_df('D')
     assert infer_time_series_resolution(df.iloc[::2,:]) == None
+
+
+
+def test_time_series_resolution_duration():
+    assert time_series_resolution_duration('D') == 1.0 / 365
+    assert time_series_resolution_duration('B') == 1.0 / 252
+    assert time_series_resolution_duration('W') == 7.0 / 365
+    assert time_series_resolution_duration('ME') == 1.0 / 12
+    assert time_series_resolution_duration('MS') == 1.0 / 12
+    assert time_series_resolution_duration('QE') == 1.0 / 4
+    assert time_series_resolution_duration('QS') == 1.0 / 4
+    assert time_series_resolution_duration('YE') == 1.0
+    assert time_series_resolution_duration('YS') == 1.0
+    assert time_series_resolution_duration('Banana') is None
+    assert time_series_resolution_duration(None) is None
+    


### PR DESCRIPTION
Added a function that converts the Pandas time series frequency strings like "D" (day), "ME" (Month End) to an typical duration in years.

The duration in years is needed in various quantitative algorithms, e.g. in time series simulations, annualising volatility etc.